### PR TITLE
feat: `no-skip` flag

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -8,13 +8,14 @@ import * as path from "./deps/std/path.ts"
 import { readerFromStreamReader, writeAll } from "./deps/std/streams.ts"
 import { parseFrontmatter } from "./frontmatter.ts"
 
-const { _: includePatterns, reload, ...rest } = parseFlags(Deno.args, {
+const { _: includePatterns, reload, unskip, ...rest } = parseFlags(Deno.args, {
   alias: {
     b: "browser",
     c: "concurrency",
     p: "project",
     r: "reload",
   },
+  boolean: ["unskip"],
   string: ["browser", "concurrency", "project", "reload"],
   default: {
     concurrency: Infinity,
@@ -66,7 +67,7 @@ await runWithConcurrency(
       },
     })
     const quotedPathname = `"${pathname}"`
-    if (frontmatter.test_skip) {
+    if (!unskip && frontmatter.test_skip) {
       console.log(yellow("Skipping"), quotedPathname)
       skipped++
       return

--- a/test.ts
+++ b/test.ts
@@ -72,6 +72,7 @@ await runWithConcurrency(
       skipped++
       return
     }
+    console.log(gray("Testing"), quotedPathname)
     const logs = new Buffer()
     const code = await (browser ? runBrowser : runDeno)(pathname, logs)
     passed++

--- a/test.ts
+++ b/test.ts
@@ -8,14 +8,14 @@ import * as path from "./deps/std/path.ts"
 import { readerFromStreamReader, writeAll } from "./deps/std/streams.ts"
 import { parseFrontmatter } from "./frontmatter.ts"
 
-const { _: includePatterns, reload, unskip, ...rest } = parseFlags(Deno.args, {
+const { _: includePatterns, reload, "no-skip": noSkip, ...rest } = parseFlags(Deno.args, {
   alias: {
     b: "browser",
     c: "concurrency",
     p: "project",
     r: "reload",
   },
-  boolean: ["unskip"],
+  boolean: ["no-skip"],
   string: ["browser", "concurrency", "project", "reload"],
   default: {
     concurrency: Infinity,
@@ -67,12 +67,11 @@ await runWithConcurrency(
       },
     })
     const quotedPathname = `"${pathname}"`
-    if (!unskip && frontmatter.test_skip) {
-      console.log(yellow("Skipping"), quotedPathname)
+    if (!noSkip && frontmatter.test_skip) {
+      console.log(yellow("Skipped"), quotedPathname)
       skipped++
       return
     }
-    console.log(gray("Testing"), quotedPathname)
     const logs = new Buffer()
     const code = await (browser ? runBrowser : runDeno)(pathname, logs)
     passed++

--- a/words.txt
+++ b/words.txt
@@ -3,4 +3,3 @@ datetime
 dprint
 egts
 frontmatter
-unskip

--- a/words.txt
+++ b/words.txt
@@ -3,3 +3,4 @@ datetime
 dprint
 egts
 frontmatter
+unskip


### PR DESCRIPTION
I often use egts locally and would like to disable the (useful-for-speeding-CI) `@test_skip` directive. This PR introduces an `unskip` boolean flag.

```diff
- deno run -A https://deno.land/x/egts@v0.1.0/test.ts 'examples/**/*.eg.ts'
+ deno run -A https://deno.land/x/egts@v0.1.0/test.ts --no-skip 'examples/**/*.eg.ts'
```